### PR TITLE
Add a GitHub Actions workflow to lint prose using Vale

### DIFF
--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -1,0 +1,18 @@
+name: Prose
+on: [push]
+
+jobs:
+  lint:
+    name: Run linter
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Vale
+      uses: errata-ai/vale-action@v1.4.0
+      with:
+        styles: https://github.com/errata-ai/proselint/releases/download/v0.3.2/proselint.zip
+        onlyAnnotateModifiedLines: true
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .github/styles
+MinAlertLevel = suggestion # suggestion, warning, or error
+
+[*.{md,rst}]
+BasedOnStyles = proselint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hunting Unicorns With Goblin Technology: A Quick Start Guide
 
-[![Build status](https://readthedocs.org/projects/hunting-unicorns/badge/?version=latest)](http://hunting-unicorns.readthedocs.io/en/latest/?badge=latest)
+[![Build status](https://readthedocs.org/projects/hunting-unicorns/badge/?version=latest)](http://hunting-unicorns.readthedocs.io/en/latest/?badge=latest) [![Total alerts](https://img.shields.io/lgtm/alerts/g/norosa/hunting-unicorns.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/norosa/hunting-unicorns/alerts/)
 
 This documentation project is written in [reStructuredText](http://sphinx-doc.org/rest.html) (RST) and is built using [Sphinx](http://www.sphinx-doc.org/) with the [Read the Docs theme](https://github.com/snide/sphinx_rtd_theme).
 
@@ -16,6 +16,7 @@ The [live docs](https://hunting-unicorns.readthedocs.io/) are hosted on RTD.
       - [Manual build](#manual-build)
       - [Autobuild with live-reloads](#autobuild-with-live-reloads)
     + [Troubleshooting](#troubleshooting)
+  * [Continuous integration](#continuous-integration)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -151,6 +152,20 @@ If you experience any other issues, try resetting the Python virtual environment
 ```console
 $ rm -rf _venv
 ```
+
+## Continuous integration
+
+Every pull request must satisfy all configured checks before being merged:
+
+- A [GitHub Actions](https://github.com/features/actions) workflow named [Prose](https://github.com/norosa/hunting-unicorns/blob/nomi/vale/.github/workflows/prose.yml) has two steps:
+
+  1. **Run linter** uses the [official GitHub Vale action](https://github.com/errata-ai/vale-action) to lint all Markdown and RST files. We have configured [Vale](https://github.com/errata-ai/vale) to use [proselint](https://github.com/errata-ai/proselint) as an initial experiment. However, this setup has the possibility of being expanded into an automated style guide.
+
+  2. **Vale** reports any lint messages produced for lines modified by the pull request. Each message carries an associated severity: *suggestion*, *warning*, and *error*. Errors and warnings must be resolved. Suggestions may be ignored.
+
+- [Read The Docs](https://docs.readthedocs.io/en/stable/pull-requests.html) attempts to build Sphinx docs on every pull request. If the build succeeds, you can select *Details* on this check to preview the documentation on the corresponding branch.
+
+- [LGTM](https://lgtm.com/) analyzes Python code for common security issues. Select *Details* on this check for information about any detected issues.
 
 ## Contributing
 


### PR DESCRIPTION
[Vale][1] is "a syntax-aware linter for prose built with speed and extensibility in mind." The [official GitHub Vale action][2] allows you to run Vale against pull requests, providing line-based lint annotations.

This change configures a basic Vale setup using [proselint][3] as an initial experiment. However, this setup has the possibility of being expanded into an automated style guide.

In addition to this change, I expanded `README.md` with a new section, *Continuous integration*, that documents all current pull request checks.

[1]: https://github.com/errata-ai/vale
[2]: https://github.com/errata-ai/vale-action
[3]: https://github.com/errata-ai/proselint